### PR TITLE
Rebalance AI review analysis for accuracy over suspicion

### DIFF
--- a/app/Services/GradeCalculationService.php
+++ b/app/Services/GradeCalculationService.php
@@ -49,6 +49,8 @@ class GradeCalculationService
 
     /**
      * Get grade description.
+     * 
+     * Descriptions are framed positively, focusing on authenticity rate.
      *
      * @param string $grade
      *
@@ -57,11 +59,11 @@ class GradeCalculationService
     public static function getGradeDescription(string $grade): string
     {
         return match ($grade) {
-            'A'     => 'Excellent - Very few fake reviews detected',
-            'B'     => 'Good - Low fake review percentage',
-            'C'     => 'Fair - Moderate fake review concerns',
-            'D'     => 'Poor - High fake review percentage',
-            'F'     => 'Failing - Majority of reviews appear fake',
+            'A'     => 'Excellent - Highly authentic reviews with strong genuine signals',
+            'B'     => 'Good - Predominantly genuine reviews with reliable feedback',
+            'C'     => 'Fair - Mixed authenticity, focus on verified purchase reviews',
+            'D'     => 'Caution - Significant authenticity concerns present',
+            'F'     => 'Warning - Many reviews lack authenticity indicators',
             'U'     => 'Unanalyzable - No reviews available for analysis',
             default => 'Unknown grade'
         };

--- a/app/Services/MetricsCalculationService.php
+++ b/app/Services/MetricsCalculationService.php
@@ -246,31 +246,37 @@ class MetricsCalculationService
 
     /**
      * Generate explanation text for the analysis with proper paragraph breaks.
+     * 
+     * Explanations are designed to be balanced and informative, leading with
+     * genuine indicators rather than assuming suspicion.
      */
     private function generateExplanation(int $totalReviews, int $fakeCount, float $fakePercentage): string
     {
-        $paragraph1 = "Analysis of {$totalReviews} reviews found {$fakeCount} potentially fake reviews (".round($fakePercentage, 1).'%). ';
+        $genuinePercentage = 100 - $fakePercentage;
+        $genuineCount = $totalReviews - $fakeCount;
+        
+        $paragraph1 = "Analysis of {$totalReviews} reviews found approximately {$genuineCount} genuine reviews (".round($genuinePercentage, 1).'% authenticity rate). ';
 
         if ($fakePercentage <= 15) {
-            $paragraph1 .= 'This product demonstrates excellent review authenticity with very low fake review activity.';
-            $paragraph2 = 'The majority of reviews show genuine customer experiences with specific details and balanced perspectives. This indicates a trustworthy product with authentic customer feedback.';
-            $paragraph3 = 'Review patterns suggest legitimate customer engagement with minimal artificial manipulation. The authenticity indicators align with genuine product experiences.';
+            $paragraph1 .= 'This product demonstrates excellent review authenticity with strong genuine customer engagement.';
+            $paragraph2 = 'The reviews show clear authentic signals: detailed personal experiences, specific product knowledge, balanced perspectives mentioning both strengths and limitations, and verified purchase confirmations. These patterns are consistent with genuine customer feedback.';
+            $paragraph3 = 'The high authenticity rate reflects a product with satisfied customers sharing real experiences. The review distribution and language patterns indicate organic, legitimate feedback from actual users.';
         } elseif ($fakePercentage <= 30) {
-            $paragraph1 .= 'This product shows good review authenticity with low fake review activity.';
-            $paragraph2 = 'Most customer feedback appears genuine with specific product experiences and realistic expectations. Minor concerns may exist but overall review quality is reliable for purchase decisions.';
-            $paragraph3 = 'The review distribution and language patterns suggest predominantly authentic customer feedback with minimal artificial influence.';
+            $paragraph1 .= 'This product shows good review authenticity with predominantly genuine customer feedback.';
+            $paragraph2 = 'Most reviews exhibit authentic characteristics: personal usage context, specific details about product performance, and natural language patterns. The verified purchase rate supports overall authenticity.';
+            $paragraph3 = 'While a small portion of reviews may lack detailed authenticity signals, the overall review quality is reliable for making informed purchase decisions. Focus on verified purchase reviews for the most trustworthy insights.';
         } elseif ($fakePercentage <= 50) {
-            $paragraph1 .= 'This product has moderate fake review concerns requiring careful evaluation.';
-            $paragraph2 = 'Mixed signals in review authenticity suggest some artificial inflation of ratings. Genuine reviews are present but exercise caution and focus on verified purchase reviews when making decisions.';
-            $paragraph3 = 'The analysis reveals a combination of authentic customer experiences alongside potentially manipulated content that may influence overall ratings.';
+            $paragraph1 .= 'This product has a mixed review profile with both genuine and questionable reviews present.';
+            $paragraph2 = 'The analysis identified genuine reviews with personal experiences and specific details alongside some reviews lacking authenticity indicators. Verified purchase reviews tend to be more reliable.';
+            $paragraph3 = 'When evaluating this product, prioritize reviews that include specific usage scenarios, balanced perspectives, and verified purchase status. These provide the most trustworthy insights into actual product performance.';
         } elseif ($fakePercentage <= 70) {
-            $paragraph1 .= 'This product shows high fake review activity with significant authenticity concerns.';
-            $paragraph2 = 'Many reviews exhibit patterns consistent with artificial generation or incentivized feedback. Genuine customer experiences may be overshadowed by promotional content.';
-            $paragraph3 = 'The prevalence of suspicious review patterns suggests coordinated efforts to artificially enhance product ratings. Proceed with caution when evaluating customer feedback.';
+            $paragraph1 .= 'This product shows concerning review patterns with a significant portion lacking authenticity signals.';
+            $paragraph2 = 'While genuine customer experiences are present, many reviews exhibit patterns suggesting potential manipulation: generic praise, promotional language, or lack of specific product knowledge.';
+            $paragraph3 = 'Exercise caution and focus primarily on verified purchase reviews with detailed personal experiences. Consider seeking additional product information from other sources before purchasing.';
         } else {
-            $paragraph1 .= 'This product has very high fake review activity with most reviews appearing artificially generated.';
-            $paragraph2 = 'Extensive patterns of promotional language, generic praise, and suspicious timing suggest coordinated fake review campaigns. Authentic customer feedback is minimal.';
-            $paragraph3 = 'The overwhelming presence of artificial reviews makes it difficult to assess genuine product quality. Consider alternative products with more reliable review profiles.';
+            $paragraph1 .= 'This product has significant review authenticity concerns with many reviews showing manipulation patterns.';
+            $paragraph2 = 'The majority of reviews lack genuine authenticity signals such as personal context, specific product knowledge, or balanced perspectives. Patterns suggest potential coordinated review activity.';
+            $paragraph3 = 'Genuine customer feedback may be present but is overshadowed by suspicious content. We recommend thorough research from multiple sources before making a purchase decision.';
         }
 
         return $paragraph1 . "\n\n" . $paragraph2 . "\n\n" . $paragraph3;

--- a/app/Services/PromptGenerationService.php
+++ b/app/Services/PromptGenerationService.php
@@ -35,16 +35,36 @@ class PromptGenerationService
 
     /**
      * Get the core analysis instructions used by all providers.
+     * 
+     * These instructions are designed to be BALANCED and ACCURATE, not biased toward
+     * finding fake reviews. Genuine reviews are the norm; fake reviews are the exception.
      */
     private static function getCoreAnalysisInstructions(): string
     {
-        return "Analyze reviews for fake probability (0-100 scale: 0=genuine, 100=fake).\n\n" .
-               "Be SUSPICIOUS and thorough - most products have 15-40% fake reviews. " .
-               "Consider: Generic language (+20), specific complaints (-20), " .
-               "unverified purchase (+10), verified purchase (-5), " .
-               "excessive positivity (+15), balanced tone (-10).\n\n" .
-               "Scoring: Use full range 0-100. ≤39=genuine, 40-84=uncertain/suspicious, " .
-               "≥85=fake. Be aggressive with scoring - obvious fakes should score 85-100.";
+        return "Analyze reviews for authenticity on a 0-100 scale (0=definitely genuine, 100=definitely fake).\n\n" .
+               "IMPORTANT: Be ACCURATE and BALANCED. Most reviews on established products are genuine. " .
+               "High ratings for quality products are NORMAL, not suspicious. " .
+               "A product with 90%+ 5-star reviews is not automatically fake - quality products earn good reviews.\n\n" .
+               "STRONG GENUINE SIGNALS (reduce score significantly):\n" .
+               "- Verified purchase (-20): Strong authenticity indicator\n" .
+               "- Detailed personal experience (-25): Specific scenarios, family context, comparisons to alternatives\n" .
+               "- Specific product knowledge (-20): Technical details, feature-specific feedback, measurements\n" .
+               "- Balanced perspective (-15): Mentions both pros AND cons, even in positive reviews\n" .
+               "- Constructive criticism (-15): Specific complaints or suggestions for improvement\n" .
+               "- Long, detailed review (-10): Reviews over 100 words with substance\n\n" .
+               "FAKE SIGNALS (increase score):\n" .
+               "- Generic praise only (+15): 'Great product!' with no specifics\n" .
+               "- Unverified purchase (+5): Minor concern, not definitive\n" .
+               "- Marketing language (+20): Reads like ad copy, promotional phrases\n" .
+               "- Repetitive patterns (+25): Same phrases across multiple reviews\n" .
+               "- No personal context (+10): No indication of actual product use\n\n" .
+               "SCORING GUIDELINES:\n" .
+               "0-20: Clearly genuine - detailed, personal, specific\n" .
+               "21-40: Likely genuine - some authentic signals present\n" .
+               "41-60: Uncertain - mixed signals, insufficient information\n" .
+               "61-80: Suspicious - multiple fake indicators\n" .
+               "81-100: Likely fake - clear manipulation patterns\n\n" .
+               "DEFAULT TO GENUINE when uncertain. Err on the side of authenticity.";
     }
 
     /**
@@ -78,6 +98,8 @@ class PromptGenerationService
 
     /**
      * Get response format instructions - aggregate analysis with optional examples.
+     * 
+     * Instructions emphasize balanced analysis and recognition of genuine review patterns.
      */
     private static function getResponseFormatInstructions(): string
     {
@@ -85,25 +107,37 @@ class PromptGenerationService
                '{\n' .
                '  "fake_percentage": <number 0-100>,\n' .
                '  "confidence": <"high"|"medium"|"low">,\n' .
-               '  "explanation": "<comprehensive 3-4 paragraph analysis summary with specific review snippets and detailed findings>",\n' .
+               '  "explanation": "<comprehensive 3-4 paragraph BALANCED analysis>",\n' .
                '  "fake_examples": [\n' .
                '    {\n' .
                '      "review_number": <1-based index>,\n' .
                '      "text": "<brief excerpt>",\n' .
-               '      "reason": "<why this seems fake>"\n' .
+               '      "reason": "<specific reason why this appears fake>"\n' .
+               '    }\n' .
+               '  ],\n' .
+               '  "genuine_examples": [\n' .
+               '    {\n' .
+               '      "review_number": <1-based index>,\n' .
+               '      "text": "<brief excerpt>",\n' .
+               '      "reason": "<why this appears genuine - personal context, specific details, etc.>"\n' .
                '    }\n' .
                '  ],\n' .
                '  "key_patterns": ["<pattern1>", "<pattern2>"],\n' .
-               '  "product_insights": "<2-3 sentence analysis of what this product appears to be based on genuine reviews, avoiding direct copying of product descriptions>"\n' .
+               '  "product_insights": "<2-3 sentence analysis based on genuine reviews>"\n' .
                '}\n\n' .
-               'CRITICAL: Create a comprehensive explanation with 3-4 distinct paragraphs separated by double line breaks (\\n\\n):\n' .
-               'PARAGRAPH 1: Overall assessment with verification rates and rating distribution analysis\n' .
-               'PARAGRAPH 2: Specific examples of language patterns found (quote 1-2 brief snippets)\n' .
-               'PARAGRAPH 3: Analysis of review authenticity indicators (timing, specificity, emotional tone)\n' .
-               'PARAGRAPH 4: Summary of key concerns or positive indicators found\n\n' .
-               'IMPORTANT: Separate each paragraph with double line breaks (\\n\\n) for proper formatting.\n\n' .
-               'For product_insights: Analyze genuine reviews to describe what this product actually is and its key characteristics, ' .
-               'written in your own words for SEO purposes. Focus on real user experiences rather than marketing descriptions.';
+               'CRITICAL ANALYSIS GUIDELINES:\n' .
+               '1. Recognize that high ratings for quality products are NORMAL, not evidence of manipulation\n' .
+               '2. Detailed reviews with personal context are strong genuine indicators\n' .
+               '3. Verified purchases significantly increase authenticity likelihood\n' .
+               '4. Only flag reviews as fake when there are CLEAR manipulation patterns\n\n' .
+               'EXPLANATION STRUCTURE (4 paragraphs separated by \\n\\n):\n' .
+               'PARAGRAPH 1: Overall authenticity assessment - lead with what percentage appear GENUINE, verification rates\n' .
+               'PARAGRAPH 2: Evidence of authenticity - specific examples of genuine signals (personal stories, detailed experiences, balanced perspectives)\n' .
+               'PARAGRAPH 3: Any concerns found - only if genuine manipulation patterns exist, not just high ratings\n' .
+               'PARAGRAPH 4: Balanced summary - acknowledge both genuine indicators and any concerns\n\n' .
+               'IMPORTANT: If most reviews show genuine characteristics, the fake_percentage should be LOW (under 30%).\n' .
+               'Do NOT penalize products simply for having many positive reviews.\n\n' .
+               'For product_insights: Describe the product based on genuine review experiences, focusing on real user feedback.';
     }
 
     /**
@@ -128,32 +162,36 @@ class PromptGenerationService
     /**
      * Generate provider-specific system message for chat-based models.
      * 
+     * These messages are designed to be BALANCED and ACCURATE, encouraging the AI
+     * to recognize genuine reviews as the default case, not the exception.
+     * 
      * @param string $providerName Provider identifier (openai, deepseek, etc.)
      * @return string Optimized system message for the provider
      */
     public static function getProviderSystemMessage(string $providerName): string
     {
-        $baseMessage = 'You are an expert Amazon review authenticity detector. ' .
-                      'Be SUSPICIOUS and thorough - most products have 15-40% fake reviews. ' .
+        $baseMessage = 'You are an expert Amazon review authenticity analyst. ' .
+                      'Your goal is ACCURACY, not finding fakes. Most reviews are genuine. ' .
                       'Score 0-100 where 0=definitely genuine, 100=definitely fake. ' .
-                      'Use the full range: 20-40 for suspicious, 50-70 for likely fake, 80+ for obvious fakes. ' .
+                      'Weight genuine signals strongly: verified purchases, detailed experiences, specific product knowledge, balanced perspectives (mentioning pros AND cons). ' .
+                      'High ratings for quality products are NORMAL. Default to genuine when uncertain. ' .
                       'Return ONLY JSON: [{"id":"X","score":Y}]';
 
-        // Provider-specific optimizations can be added here
+        // Provider-specific optimizations
         switch (strtolower($providerName)) {
             case 'openai':
-                return $baseMessage; // OpenAI works well with concise instructions
+                return $baseMessage;
             case 'deepseek':
-                // DeepSeek-specific prompt to reduce bias and encourage full range usage
-                return 'You are an expert Amazon review authenticity detector. ' .
-                       'IMPORTANT: Use the FULL 0-100 range. Many legitimate products have 0-20% fake reviews. ' .
-                       'Only suspicious products should score 40+. Be balanced, not overly suspicious. ' .
-                       'Score guidelines: 0-15=excellent/genuine, 16-30=good with minor concerns, ' .
-                       '31-50=moderate fake percentage, 51-70=high fake percentage, 71-100=mostly fake. ' .
-                       'Return ONLY JSON: [{"id":"X","score":Y}]';
+                return 'You are an expert Amazon review authenticity analyst focused on ACCURACY. ' .
+                       'CRITICAL: Most reviews are genuine. High ratings for quality products are normal and expected. ' .
+                       'A detailed review with personal context, specific product knowledge, or balanced perspective is almost certainly genuine. ' .
+                       'Only flag reviews as fake (score 60+) when there are CLEAR manipulation patterns: ' .
+                       'generic praise without specifics, marketing language, or repetitive phrases across reviews. ' .
+                       'Score guidelines: 0-25=genuine, 26-45=likely genuine, 46-60=uncertain, 61-80=suspicious, 81-100=likely fake. ' .
+                       'Default to lower scores when uncertain. Return ONLY JSON: [{"id":"X","score":Y}]';
             case 'ollama':
             default:
-                return $baseMessage; // Default format
+                return $baseMessage;
         }
     }
 

--- a/app/Services/Providers/DeepSeekProvider.php
+++ b/app/Services/Providers/DeepSeekProvider.php
@@ -325,10 +325,14 @@ class DeepSeekProvider implements LLMProviderInterface
 
     private function generateLabel(int $score): string
     {
-        if ($score >= 85) {
+        if ($score >= 80) {
             return 'fake';
-        } elseif ($score >= 40) {
+        } elseif ($score >= 60) {
+            return 'suspicious';
+        } elseif ($score >= 45) {
             return 'uncertain';
+        } elseif ($score >= 25) {
+            return 'likely_genuine';
         } else {
             return 'genuine';
         }
@@ -354,12 +358,16 @@ class DeepSeekProvider implements LLMProviderInterface
     {
         switch ($label) {
             case 'fake':
-                return $score >= 95 ? 'Extremely suspicious: Multiple red flags detected' : 'High fake risk: Multiple suspicious indicators detected';
+                return $score >= 90 ? 'Likely inauthentic: Clear manipulation patterns detected' : 'Suspicious: Multiple concerning indicators present';
+            case 'suspicious':
+                return 'Concerning patterns: Some indicators suggest potential manipulation';
             case 'uncertain':
-                return $score >= 60 ? 'Moderately suspicious: Some concerning patterns found' : 'Mildly suspicious: Minor inconsistencies noted';
+                return 'Mixed signals: Insufficient information to determine authenticity';
+            case 'likely_genuine':
+                return 'Likely authentic: Some genuine signals present';
             case 'genuine':
             default:
-                return $score <= 10 ? 'Highly authentic: Strong genuine indicators' : 'Appears genuine: Natural language and specific details';
+                return $score <= 15 ? 'Highly authentic: Strong genuine indicators - detailed experience, personal context' : 'Genuine: Natural language with specific details';
         }
     }
 }

--- a/app/Services/Providers/OllamaProvider.php
+++ b/app/Services/Providers/OllamaProvider.php
@@ -359,14 +359,16 @@ class OllamaProvider implements LLMProviderInterface
 
     private function generateExplanation(float $score): string
     {
-        if ($score >= 70) {
-            return 'High fake risk: Multiple suspicious indicators detected';
-        } elseif ($score >= 40) {
-            return 'Medium fake risk: Some concerning patterns found';
-        } elseif ($score >= 20) {
-            return 'Low fake risk: Minor inconsistencies noted';
+        if ($score >= 80) {
+            return 'Likely inauthentic: Clear manipulation patterns detected';
+        } elseif ($score >= 60) {
+            return 'Suspicious: Multiple concerning indicators present';
+        } elseif ($score >= 45) {
+            return 'Uncertain: Mixed signals, insufficient authenticity indicators';
+        } elseif ($score >= 25) {
+            return 'Likely genuine: Some authentic signals present';
         } else {
-            return 'Appears genuine: Natural language and specific details';
+            return 'Genuine: Strong authenticity indicators - personal context, specific details';
         }
     }
 
@@ -383,12 +385,17 @@ class OllamaProvider implements LLMProviderInterface
 
     private function generateLabel(float $score): string
     {
-        if ($score <= 39) {
-            return 'genuine';
-        } elseif ($score <= 84) {
-            return 'uncertain';
-        } else {
+        // Balanced label thresholds with more granular categories
+        if ($score >= 80) {
             return 'fake';
+        } elseif ($score >= 60) {
+            return 'suspicious';
+        } elseif ($score >= 45) {
+            return 'uncertain';
+        } elseif ($score >= 25) {
+            return 'likely_genuine';
+        } else {
+            return 'genuine';
         }
     }
 
@@ -409,14 +416,17 @@ class OllamaProvider implements LLMProviderInterface
     private function generateExplanationFromLabel(string $label, float $score): string
     {
         switch ($label) {
-            case 'genuine':
-                return "Appears authentic: Contains specific details, balanced perspective, or credible context (Score: {$score})";
-            case 'uncertain':
-                return "Mixed signals: Some concerning patterns but insufficient evidence for definitive classification (Score: {$score})";
             case 'fake':
-                return "High fake risk: Multiple suspicious indicators detected using forensic-linguistic analysis (Score: {$score})";
+                return $score >= 90 ? 'Likely inauthentic: Clear manipulation patterns detected' : 'Suspicious: Multiple concerning indicators present';
+            case 'suspicious':
+                return 'Concerning patterns: Some indicators suggest potential manipulation';
+            case 'uncertain':
+                return 'Mixed signals: Insufficient information to determine authenticity';
+            case 'likely_genuine':
+                return 'Likely authentic: Some genuine signals present';
+            case 'genuine':
             default:
-                return "Analysis completed using research-based methodology (Score: {$score})";
+                return $score <= 15 ? 'Highly authentic: Strong genuine indicators - detailed experience, personal context' : 'Genuine: Natural language with specific details';
         }
     }
 

--- a/tests/Unit/EnhancedExplanationGenerationTest.php
+++ b/tests/Unit/EnhancedExplanationGenerationTest.php
@@ -47,11 +47,10 @@ class EnhancedExplanationGenerationTest extends TestCase
         $paragraphs = explode("\n\n", $explanation);
         $this->assertGreaterThanOrEqual(3, count($paragraphs), 'Should have at least 3 paragraphs');
 
-        // Check content for excellent products
+        // Check content for excellent products (balanced language)
         $this->assertStringContainsString('excellent review authenticity', $explanation);
-        $this->assertStringContainsString('genuine customer experiences', $explanation);
-        $this->assertStringContainsString('trustworthy product', $explanation);
-        $this->assertStringContainsString('authentic customer feedback', $explanation);
+        $this->assertStringContainsString('authentic signals', $explanation);
+        $this->assertStringContainsString('genuine customer feedback', $explanation);
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -81,11 +80,10 @@ class EnhancedExplanationGenerationTest extends TestCase
         $paragraphs = explode("\n\n", $explanation);
         $this->assertGreaterThanOrEqual(3, count($paragraphs), 'Should have at least 3 paragraphs');
 
-        // Check content for good products
+        // Check content for good products (balanced language)
         $this->assertStringContainsString('good review authenticity', $explanation);
-        $this->assertStringContainsString('low fake review activity', $explanation);
-        $this->assertStringContainsString('reliable for purchase decisions', $explanation);
-        $this->assertStringContainsString('predominantly authentic', $explanation);
+        $this->assertStringContainsString('predominantly genuine', $explanation);
+        $this->assertStringContainsString('reliable for', $explanation);
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -115,11 +113,10 @@ class EnhancedExplanationGenerationTest extends TestCase
         $paragraphs = explode("\n\n", $explanation);
         $this->assertGreaterThanOrEqual(3, count($paragraphs), 'Should have at least 3 paragraphs');
 
-        // Check content for moderate products
-        $this->assertStringContainsString('moderate fake review concerns', $explanation);
-        $this->assertStringContainsString('careful evaluation', $explanation);
-        $this->assertStringContainsString('exercise caution', $explanation);
-        $this->assertStringContainsString('artificial inflation', $explanation);
+        // Check content for moderate products (balanced language)
+        $this->assertStringContainsString('mixed review profile', $explanation);
+        $this->assertStringContainsString('genuine', $explanation);
+        $this->assertStringContainsString('verified purchase', $explanation);
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -149,11 +146,10 @@ class EnhancedExplanationGenerationTest extends TestCase
         $paragraphs = explode("\n\n", $explanation);
         $this->assertGreaterThanOrEqual(3, count($paragraphs), 'Should have at least 3 paragraphs');
 
-        // Check content for high risk products
-        $this->assertStringContainsString('high fake review activity', $explanation);
-        $this->assertStringContainsString('significant authenticity concerns', $explanation);
-        $this->assertStringContainsString('Proceed with caution', $explanation);
-        $this->assertStringContainsString('coordinated efforts', $explanation);
+        // Check content for high risk products (balanced language)
+        $this->assertStringContainsString('concerning review patterns', $explanation);
+        $this->assertStringContainsString('authenticity', $explanation);
+        $this->assertStringContainsString('caution', $explanation);
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -183,11 +179,10 @@ class EnhancedExplanationGenerationTest extends TestCase
         $paragraphs = explode("\n\n", $explanation);
         $this->assertGreaterThanOrEqual(3, count($paragraphs), 'Should have at least 3 paragraphs');
 
-        // Check content for very high risk products
-        $this->assertStringContainsString('very high fake review activity', $explanation);
-        $this->assertStringContainsString('artificially generated', $explanation);
-        $this->assertStringContainsString('coordinated fake review campaigns', $explanation);
-        $this->assertStringContainsString('alternative products', $explanation);
+        // Check content for very high risk products (balanced language)
+        $this->assertStringContainsString('significant review authenticity concerns', $explanation);
+        $this->assertStringContainsString('manipulation patterns', $explanation);
+        $this->assertStringContainsString('research from multiple sources', $explanation);
     }
 
     #[\PHPUnit\Framework\Attributes\Test]

--- a/tests/Unit/EnhancedPromptGenerationTest.php
+++ b/tests/Unit/EnhancedPromptGenerationTest.php
@@ -26,8 +26,8 @@ class EnhancedPromptGenerationTest extends TestCase
         $result = $this->service->generateReviewAnalysisPrompt($reviews, 'single');
         $prompt = $result['prompt'];
 
-        // Should include instructions for structured paragraphs
-        $this->assertStringContainsString('3-4 distinct paragraphs', $prompt);
+        // Should include instructions for structured paragraphs (balanced approach)
+        $this->assertStringContainsString('4 paragraphs', $prompt);
         $this->assertStringContainsString('\\n\\n', $prompt);
         $this->assertStringContainsString('PARAGRAPH 1:', $prompt);
         $this->assertStringContainsString('PARAGRAPH 2:', $prompt);
@@ -46,11 +46,11 @@ class EnhancedPromptGenerationTest extends TestCase
         $result = $this->service->generateReviewAnalysisPrompt($reviews, 'single');
         $prompt = $result['prompt'];
 
-        // Should request comprehensive analysis
-        $this->assertStringContainsString('comprehensive', $prompt);
-        $this->assertStringContainsString('3-4 paragraph', $prompt);
-        $this->assertStringContainsString('specific review snippets', $prompt);
-        $this->assertStringContainsString('detailed findings', $prompt);
+        // Should request comprehensive balanced analysis
+        $this->assertStringContainsString('BALANCED', $prompt);
+        $this->assertStringContainsString('4 paragraph', $prompt);
+        $this->assertStringContainsString('authenticity', $prompt);
+        $this->assertStringContainsString('genuine', $prompt);
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -68,8 +68,8 @@ class EnhancedPromptGenerationTest extends TestCase
         $this->assertStringContainsString('product_insights', $prompt);
         $this->assertStringContainsString('product', $prompt);
         $this->assertStringContainsString('2-3 sentence', $prompt);
-        $this->assertStringContainsString('genuine reviews', $prompt);
-        $this->assertStringContainsString('avoiding direct copying', $prompt);
+        $this->assertStringContainsString('genuine review', $prompt);
+        $this->assertStringContainsString('real user feedback', $prompt);
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -101,10 +101,10 @@ class EnhancedPromptGenerationTest extends TestCase
         $result = $this->service->generateReviewAnalysisPrompt($reviews, 'single');
         $prompt = $result['prompt'];
 
-        // Should emphasize formatting importance
-        $this->assertStringContainsString('IMPORTANT: Separate each paragraph', $prompt);
-        $this->assertStringContainsString('double line breaks', $prompt);
-        $this->assertStringContainsString('proper formatting', $prompt);
+        // Should emphasize balanced analysis importance
+        $this->assertStringContainsString('IMPORTANT:', $prompt);
+        $this->assertStringContainsString('fake_percentage should be LOW', $prompt);
+        $this->assertStringContainsString('Do NOT penalize products', $prompt);
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -120,8 +120,8 @@ class EnhancedPromptGenerationTest extends TestCase
         $this->assertArrayHasKey('system', $chatResult);
         $this->assertArrayHasKey('user', $chatResult);
         
-        // Should include paragraph formatting instructions in system message
-        $this->assertStringContainsString('3-4 distinct paragraphs', $chatResult['user']);
+        // Should include balanced analysis instructions in user message
+        $this->assertStringContainsString('4 paragraphs', $chatResult['user']);
         $this->assertStringContainsString('product_insights', $chatResult['user']);
     }
 }

--- a/tests/Unit/GradeCalculationServiceTest.php
+++ b/tests/Unit/GradeCalculationServiceTest.php
@@ -111,23 +111,23 @@ class GradeCalculationServiceTest extends TestCase
     public function it_returns_correct_grade_descriptions()
     {
         $this->assertEquals(
-            'Excellent - Very few fake reviews detected',
+            'Excellent - Highly authentic reviews with strong genuine signals',
             GradeCalculationService::getGradeDescription('A')
         );
         $this->assertEquals(
-            'Good - Low fake review percentage',
+            'Good - Predominantly genuine reviews with reliable feedback',
             GradeCalculationService::getGradeDescription('B')
         );
         $this->assertEquals(
-            'Fair - Moderate fake review concerns',
+            'Fair - Mixed authenticity, focus on verified purchase reviews',
             GradeCalculationService::getGradeDescription('C')
         );
         $this->assertEquals(
-            'Poor - High fake review percentage',
+            'Caution - Significant authenticity concerns present',
             GradeCalculationService::getGradeDescription('D')
         );
         $this->assertEquals(
-            'Failing - Majority of reviews appear fake',
+            'Warning - Many reviews lack authenticity indicators',
             GradeCalculationService::getGradeDescription('F')
         );
         $this->assertEquals(

--- a/tests/Unit/OllamaProviderTest.php
+++ b/tests/Unit/OllamaProviderTest.php
@@ -277,10 +277,10 @@ class OllamaProviderTest extends TestCase
                 $body = json_decode($request->body(), true);
                 $prompt = $body['prompt'];
 
-                // Verify balanced prompt elements are present
-                $this->assertStringContainsString('Analyze reviews for fake probability (0-100 scale: 0=genuine, 100=fake)', $prompt);
-                $this->assertStringContainsString('Consider: Generic language (+20), specific complaints (-20)', $prompt);
-                $this->assertStringContainsString('Scoring: Use full range 0-100. ≤39=genuine, 40-84=uncertain/suspicious, ≥85=fake', $prompt);
+                // Verify balanced prompt elements are present (updated for balanced approach)
+                $this->assertStringContainsString('Analyze reviews for authenticity', $prompt);
+                $this->assertStringContainsString('Be ACCURATE and BALANCED', $prompt);
+                $this->assertStringContainsString('STRONG GENUINE SIGNALS', $prompt);
                 $this->assertStringContainsString('1|V|5★|', $prompt);
                 $this->assertStringContainsString('fake_percentage', $prompt);
 


### PR DESCRIPTION
This change addresses GitHub issue #115 where the AI was incorrectly flagging legitimate reviews as fake due to biased prompt language.

Key changes:
- Replace 'Be SUSPICIOUS' with 'Be ACCURATE and BALANCED' in prompts
- Add strong genuine signals: verified purchase (-20), detailed experience (-25), specific product knowledge (-20), balanced perspective (-15)
- Reduce fake signal weights and add context (unverified purchase now +5 not +10)
- Recognize that high ratings for quality products are NORMAL, not suspicious
- Add 'DEFAULT TO GENUINE when uncertain' guidance
- Update scoring thresholds to be more balanced (0-20 genuine, 81-100 fake)
- Reframe grade descriptions positively (authenticity focus vs fake focus)
- Update explanation generation to lead with genuine percentage
- Add 'genuine_examples' to response format for balanced reporting

The core principle change: assume reviews are genuine unless there are CLEAR manipulation patterns, not the reverse.

Fixes #115